### PR TITLE
Add Python SDK example tab to project onboarding

### DIFF
--- a/src/components/code-examples.tsx
+++ b/src/components/code-examples.tsx
@@ -3,6 +3,8 @@ import { Card, CardContent } from './ui/card'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs'
 import { CurlExample } from './curl-example'
 import { TypeScriptSDKExample } from './typescript-sdk-example'
+import { PythonSDKExample } from './python-sdk-example'
+import { PythonIcon } from './icons'
 import type { Project } from 'generated/prisma/browser'
 
 type CodeExamplesProps = {
@@ -29,8 +31,12 @@ export function CodeExamples({ projectId }: CodeExamplesProps) {
                   cURL
                 </TabsTrigger>
                 <TabsTrigger value="typescript">
-                  <RiJavascriptFill />
+                  <RiJavascriptFill className="text-yellow-400" />
                   JavaScript SDK
+                </TabsTrigger>
+                <TabsTrigger value="python">
+                  <PythonIcon />
+                  Python SDK
                 </TabsTrigger>
               </TabsList>
               <TabsContent value="curl">
@@ -41,6 +47,9 @@ export function CodeExamples({ projectId }: CodeExamplesProps) {
                 className="p-2 flex flex-col gap-4"
               >
                 <TypeScriptSDKExample projectId={projectId} />
+              </TabsContent>
+              <TabsContent value="python" className="p-2 flex flex-col gap-4">
+                <PythonSDKExample projectId={projectId} />
               </TabsContent>
             </Tabs>
           </CardContent>

--- a/src/components/python-sdk-example.tsx
+++ b/src/components/python-sdk-example.tsx
@@ -1,0 +1,105 @@
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import { RiExternalLinkLine } from '@remixicon/react'
+import type { Project } from 'generated/prisma/browser'
+import { highlightCode } from '@/lib/shiki'
+
+type PythonSDKExampleProps = {
+  projectId: Project['id']
+}
+
+const UV_INSTALL_COMMAND = 'uv add logbench'
+
+export function PythonSDKExample({ projectId }: PythonSDKExampleProps) {
+  const pythonSnippet = useMemo(
+    () =>
+      `from logbench import Logbench
+
+logger = Logbench(project_id="${projectId}")
+
+logger.info("Server started on port 3000")
+logger.warn("Disk usage above 80%")
+logger.err("Failed to connect to database")`,
+    [projectId],
+  )
+
+  const { data: pythonInstallSnippet } = useQuery({
+    queryKey: ['projects', projectId, 'examples', 'python', 'install'],
+    queryFn: async () => {
+      const html = await highlightCode(UV_INSTALL_COMMAND, 'shell')
+
+      return html
+    },
+  })
+
+  const { data: pythonExample } = useQuery({
+    queryKey: ['projects', projectId, 'examples', 'python', pythonSnippet],
+    queryFn: async () => {
+      if (!pythonSnippet) {
+        return
+      }
+
+      const html = await highlightCode(pythonSnippet, 'python')
+
+      return html
+    },
+    enabled: !!pythonSnippet,
+  })
+
+  if (!pythonSnippet || !pythonExample || !pythonInstallSnippet) {
+    return null
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1.75">
+        <h3 className="text-base font-mediumn">Python SDK</h3>
+
+        <p className="text-muted-foreground text-xs/relaxed text-balance">
+          The SDK for Python is a small wrapper around requests that helps with
+          serialization of non-json objects. If you prefer to implement this
+          yourself, you can check out the code on{' '}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/albingroen/logbench-python/blob/main/logbench/__init__.py"
+            className="underline underline-offset-4 inline-flex items-center gap-0.75 decoration-muted-foreground/50 hover:decoration-foreground hover:text-foreground"
+          >
+            <span>GitHub</span> <RiExternalLinkLine className="size-3.5" />
+          </a>
+          .
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <p className="text-sm">1. Install the SDK in your project</p>
+        <div
+          className="code-example"
+          dangerouslySetInnerHTML={{ __html: pythonInstallSnippet }}
+        />
+      </div>
+
+      <div className="flex flex-col gap-3.5">
+        <div className="flex flex-col gap-2">
+          <p className="text-sm">2. Send your first log</p>
+          <div
+            className="code-example"
+            dangerouslySetInnerHTML={{ __html: pythonExample }}
+          />
+        </div>
+
+        <p className="text-muted-foreground text-xs">
+          Want to learn more about the Python SDK? Head to the{' '}
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://github.com/albingroen/logbench-python"
+            className="underline underline-offset-4 inline-flex items-center gap-0.75 decoration-muted-foreground/50 hover:decoration-foreground hover:text-foreground"
+          >
+            <span>docs</span> <RiExternalLinkLine className="size-3.5" />
+          </a>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/shiki.ts
+++ b/src/lib/shiki.ts
@@ -9,6 +9,7 @@ const highlighterPromise = createHighlighterCore({
     import('@shikijs/langs/javascript'),
     import('@shikijs/langs/shell'),
     import('@shikijs/langs/json'),
+    import('@shikijs/langs/python'),
   ],
   engine: createJavaScriptRegexEngine(),
 })


### PR DESCRIPTION
Adds a new "Python SDK" tab in the code examples section shown when a
project has no logs yet. Includes install instructions (pip install logbench)
and a usage snippet, with syntax highlighting via Shiki and a link to the
logbench-python GitHub repository.

https://claude.ai/code/session_01Pi8x43NpxbbfykW56jKiiA